### PR TITLE
Allow provision of stream options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 var through = require('through2');
 
-module.exports = function (userCb) {
-	var stream = through.obj(function (file, enc, cb) {
+module.exports = function (userCb, options) {
+	options = options || {};
+	var stream = through.obj(options, function (file, enc, cb) {
 		this.paths.push(file.path);
 
 		if (userCb) {


### PR DESCRIPTION
Currently this library does not allow the user to provide any options, thereby defaulting to readable-stream's stream options. This makes it impossible to process any stream that matches more than 16 files. Allowing users to provide an option makes it possible to override this behaviour.