### PR TITLE
Fix regression in v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = pathCallback => {
 		if (pathCallback) {
 			(async () => {
 				try {
-					callback(null, await pathCallback(file.path));
+					await pathCallback(file.path);
+					callback(null, file);
 				} catch (error) {
 					callback(error);
 				}


### PR DESCRIPTION
Resolves #7 for me. I've been using the gulp recipe found at https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md as a base for one of my tasks, which stopped working for with vinyl-paths 3.0.0. In version 2.1.0 the vinyl object `file` was passed on to the next stage in the pipeline, whereas in 3.0.0 it is the return value of the user callback (`pathCallback`) that is passed on. Is that an intended change?

Maybe it would also be good to move the callbacks out of the `try...catch` blocks. When an error occurs in the `callback` inside the `try` block, the error gets caught, and instead it seems the `callback` function gets called a second time, inside the `catch` block, causing the "Error: write callback called multiple times", hiding the original cause of the error.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#7: It seems like v3.0.0 breaks my build](https://issuehunt.io/repos/26579795/issues/7)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->